### PR TITLE
Update README to include running fix-cockpit script to load missing fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ $ git clone https://github.com/45drives/cockpit-zfs-manager.git
 $ sudo cp -r cockpit-zfs-manager/zfs /usr/share/cockpit
 ```
 
+Update Cockpit fonts (required for Cockpit >= 277)
+
+```bash
+$ curl https://raw.githubusercontent.com/45Drives/scripts/main/cockpit_font_fix/fix-cockpit.sh | sudo bash
+```
+
+<sub>see [this issue](https://github.com/45Drives/cockpit-zfs-manager/issues/15) for more information around the missing fonts</sub>
+
+Finally, restart cockpit to load the missing fonts
+
 #### Samba
 
 Auto generated snapshot names are created in YYYY.MM.DD-HH.MM.SS format.


### PR DESCRIPTION
This PR adds a step to the install section of the README to run the 45Drives `fix-cockpit` script as mentioned in [this issue](https://github.com/45Drives/cockpit-zfs-manager/issues/15) when installing this plugin on newer versions of Cockpit so the icons and fonts can render correctly.